### PR TITLE
override `VertxServer.getPort` to return actual port

### DIFF
--- a/src/main/java/io/vertx/grpc/VertxServer.java
+++ b/src/main/java/io/vertx/grpc/VertxServer.java
@@ -151,6 +151,11 @@ public class VertxServer extends Server {
   }
 
   @Override
+  public int getPort() {
+    return actual.server.getPort();
+  }
+
+  @Override
   public VertxServer shutdownNow() {
     throw new UnsupportedOperationException();
   }


### PR DESCRIPTION
Currently `-1` is returned by the base class implementation of `getPort()`. Also see [mailinglist](https://groups.google.com/forum/#!topic/vertx/ibDau9z-n4o).