### PR TITLE
add test for random port server

### DIFF
--- a/src/test/java/io/vertx/ext/grpc/GrpcTestBase.java
+++ b/src/test/java/io/vertx/ext/grpc/GrpcTestBase.java
@@ -24,7 +24,7 @@ public abstract class GrpcTestBase {
   /* The port on which the server should run */
   Vertx vertx;
   int port;
-  private VertxServer server;
+  protected VertxServer server;
 
   @Before
   public void setUp() {

--- a/src/test/java/io/vertx/ext/grpc/RpcTest.java
+++ b/src/test/java/io/vertx/ext/grpc/RpcTest.java
@@ -182,4 +182,27 @@ public class RpcTest extends GrpcTestBase {
       });
     });
   }
+
+  @Test
+  public void testRandomPort(TestContext ctx) throws Exception {
+    Async started = ctx.async();
+    port = 0;
+    startServer(new GreeterGrpc.GreeterVertxImplBase() {
+      @Override
+      public void sayHello(HelloRequest req, Future<HelloReply> future) {
+        future.complete(HelloReply.newBuilder().setMessage("Hello " + req.getName()).build());
+      }
+    }, ar -> {
+      if (ar.succeeded()) {
+        started.complete();
+      } else {
+        ctx.fail(ar.cause());
+      }
+    });
+
+    started.awaitSuccess(10000);
+
+    ctx.assertTrue(server.getPort() > 0);
+    ctx.assertTrue(server.getPort() < 65536);
+  }
 }


### PR DESCRIPTION
Add a test that uses `0` as a server port number and verifies that the server starts, uses a random available port and `getPort` returns the used port (see [PR12](https://github.com/vert-x3/vertx-grpc/pull/12)).