### PR TITLE
shutdown test channels properly

### DIFF
--- a/src/test/java/io/vertx/ext/grpc/GoogleTest.java
+++ b/src/test/java/io/vertx/ext/grpc/GoogleTest.java
@@ -26,8 +26,10 @@ import static io.grpc.testing.integration.TestServiceGrpc.*;
  */
 public class GoogleTest extends GrpcTestBase {
 
+  private ManagedChannel channel;
+
   private TestServiceVertxStub buildStub() {
-    ManagedChannel channel = VertxChannelBuilder.forAddress(vertx, "localhost", port).usePlaintext(true).build();
+    channel = VertxChannelBuilder.forAddress(vertx, "localhost", port).usePlaintext(true).build();
     return newVertxStub(channel);
   }
 
@@ -50,6 +52,7 @@ public class GoogleTest extends GrpcTestBase {
             will.assertNotNull(res.result());
             test.complete();
           }
+          channel.shutdown();
         });
       } else {
         will.fail(startServer.cause());
@@ -77,6 +80,7 @@ public class GoogleTest extends GrpcTestBase {
             will.assertNotNull(res.result());
             test.complete();
           }
+          channel.shutdown();
         });
       } else {
         will.fail(startServer.cause());
@@ -115,6 +119,7 @@ public class GoogleTest extends GrpcTestBase {
             .endHandler(v -> {
               will.assertEquals(10, cnt.get());
               test.complete();
+              channel.shutdown();
             });
         });
       } else {
@@ -159,6 +164,7 @@ public class GoogleTest extends GrpcTestBase {
               } else {
                 will.assertNotNull(res.result());
                 test.complete();
+                channel.shutdown();
               }
             });
 
@@ -214,6 +220,7 @@ public class GoogleTest extends GrpcTestBase {
             .endHandler(v -> {
               will.assertEquals(10, cnt.get());
               test.complete();
+              channel.shutdown();
             });
 
           for (int i = 0; i < 10; i++) {
@@ -275,6 +282,7 @@ public class GoogleTest extends GrpcTestBase {
             .endHandler(v -> {
               will.assertEquals(10, cnt.get());
               test.complete();
+              channel.shutdown();
             });
 
           for (int i = 0; i < 10; i++) {
@@ -310,6 +318,7 @@ public class GoogleTest extends GrpcTestBase {
             will.assertNotNull(res.cause());
           }
           test.complete();
+          channel.shutdown();
         });
       } else {
         will.fail(startServer.cause());

--- a/src/test/java/io/vertx/ext/grpc/RpcTest.java
+++ b/src/test/java/io/vertx/ext/grpc/RpcTest.java
@@ -63,6 +63,7 @@ public class RpcTest extends GrpcTestBase {
         } else {
           ctx.fail(ar.cause());
         }
+        channel.shutdown();
       });
     });
   }
@@ -94,6 +95,7 @@ public class RpcTest extends GrpcTestBase {
           List<String> expected = IntStream.rangeClosed(0, numItems - 1).mapToObj(val -> "the-value-" + val).collect(Collectors.toList());
           ctx.assertEquals(expected, items);
           done.complete();
+          channel.shutdown();
         });
     });
   }
@@ -137,6 +139,7 @@ public class RpcTest extends GrpcTestBase {
         } else {
           vertx.cancelTimer(id);
           exchange.end();
+          channel.shutdown();
         }
       });
     });
@@ -178,6 +181,7 @@ public class RpcTest extends GrpcTestBase {
         } else {
           vertx.cancelTimer(id);
           exchange.end();
+          channel.shutdown();
         }
       });
     });

--- a/src/test/java/io/vertx/ext/grpc/SslTest.java
+++ b/src/test/java/io/vertx/ext/grpc/SslTest.java
@@ -143,6 +143,7 @@ public class SslTest extends GrpcTestBase {
             async.complete();
           }
         }
+        channel.shutdown();
       });
     });
   }

--- a/src/test/java/io/vertx/ext/grpc/VerticleTest.java
+++ b/src/test/java/io/vertx/ext/grpc/VerticleTest.java
@@ -91,7 +91,7 @@ public class VerticleTest {
     final int num = 10;
     Async async = ctx.async(num);
     for (int i = 0;i < num;i++) {
-      ManagedChannel channel= VertxChannelBuilder.forAddress(vertx, "localhost", 50051)
+      ManagedChannel channel = VertxChannelBuilder.forAddress(vertx, "localhost", 50051)
           .usePlaintext(true)
           .build();
       GreeterGrpc.GreeterVertxStub stub = GreeterGrpc.newVertxStub(channel);
@@ -137,6 +137,7 @@ public class VerticleTest {
     blockingStub.sayHello(request, ar -> {
       ctx.assertFalse(ar.succeeded());
       async.complete();
+      channel.shutdown();
     });
   }
 


### PR DESCRIPTION
Avoids multiple CI warnings
```
SEVERE: *~*~*~ Channel io.grpc.internal.ManagedChannelImpl-17 for target localhost:50051 was not shutdown properly!!! ~*~*~*
    Make sure to call shutdown()/shutdownNow() and awaitTermination().
java.lang.RuntimeException: ManagedChannel allocation site
	at io.grpc.internal.ManagedChannelImpl$ManagedChannelReference.<init>(ManagedChannelImpl.java:1065)
   ...
```