### PR TITLE
set vertx elg as netty boss elg

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,18 @@
       <artifactId>vertx-unit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <classifier>linux-x86_64</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-kqueue</artifactId>
+      <classifier>osx-x86_64</classifier>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/src/main/java/io/vertx/grpc/VertxServer.java
+++ b/src/main/java/io/vertx/grpc/VertxServer.java
@@ -70,6 +70,7 @@ public class VertxServer extends Server {
             contextLocal.get().get(0).executeFromIO(event -> command.run());
           })
           .channelType(transport.serverChannelType(false))
+          .bossEventLoopGroup(group)
           .workerEventLoopGroup(group)
           .build();
     }

--- a/src/test/java/io/vertx/ext/grpc/NativeTransportTest.java
+++ b/src/test/java/io/vertx/ext/grpc/NativeTransportTest.java
@@ -3,9 +3,11 @@ package io.vertx.ext.grpc;
 import examples.GreeterGrpc;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
+import io.vertx.core.net.impl.transport.Transport;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.grpc.VertxServerBuilder;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -14,11 +16,13 @@ public class NativeTransportTest {
 
   @Test
   public void testNativeTransportEnabled(TestContext ctx) {
+    assumeNativeTransport();
     testInternal(ctx, Vertx.vertx(new VertxOptions().setPreferNativeTransport(true)));
   }
 
   @Test
   public void testNativeTransportDisabled(TestContext ctx) {
+    assumeNativeTransport();
     testInternal(ctx, Vertx.vertx(new VertxOptions().setPreferNativeTransport(false)));
   }
 
@@ -27,5 +31,10 @@ public class NativeTransportTest {
       .addService(new GreeterGrpc.GreeterImplBase() { })
       .build()
       .start(ctx.asyncAssertSuccess());
+  }
+
+  private void assumeNativeTransport() {
+    Transport nativeTransport = Transport.nativeTransport();
+    Assume.assumeTrue(nativeTransport != null && nativeTransport.isAvailable());
   }
 }

--- a/src/test/java/io/vertx/ext/grpc/NativeTransportTest.java
+++ b/src/test/java/io/vertx/ext/grpc/NativeTransportTest.java
@@ -1,0 +1,31 @@
+package io.vertx.ext.grpc;
+
+import examples.GreeterGrpc;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.grpc.VertxServerBuilder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class NativeTransportTest {
+
+  @Test
+  public void testNativeTransportEnabled(TestContext ctx) {
+    testInternal(ctx, Vertx.vertx(new VertxOptions().setPreferNativeTransport(true)));
+  }
+
+  @Test
+  public void testNativeTransportDisabled(TestContext ctx) {
+    testInternal(ctx, Vertx.vertx(new VertxOptions().setPreferNativeTransport(false)));
+  }
+
+  private void testInternal(TestContext ctx, Vertx vertx) {
+    VertxServerBuilder.forPort(vertx, 0)
+      .addService(new GreeterGrpc.GreeterImplBase() { })
+      .build()
+      .start(ctx.asyncAssertSuccess());
+  }
+}


### PR DESCRIPTION
Sets the vertx event loop group as netty boss event loop group in `NettyServerBuilder` to ensure correct event loop types when using native transport. Fixes [vertx-issue 361](https://github.com/vert-x3/issues/issues/361).