### PR TITLE
Fix broken close hook

### DIFF
--- a/src/main/java/io/vertx/grpc/VertxServer.java
+++ b/src/main/java/io/vertx/grpc/VertxServer.java
@@ -140,7 +140,7 @@ public class VertxServer extends Server {
     }
     actual.start(context, ar1 -> {
       if (ar1.succeeded()) {
-        hook = ar2 -> shutdown();
+        hook = ar2 -> shutdown(ar2);
         context.addCloseHook(hook);
       }
       completionHandler.handle(ar1);


### PR DESCRIPTION
The hook was not being notified once the shutdown was complete, preventing any verticle depending on the auto close functionality from correctly undeploying.