### PR TITLE
backport required stubs from 4.0 branch to use with new compiler.

### DIFF
--- a/src/main/java/io/vertx/grpc/stub/ClientCalls.java
+++ b/src/main/java/io/vertx/grpc/stub/ClientCalls.java
@@ -1,0 +1,67 @@
+package io.vertx.grpc.stub;
+
+import io.grpc.stub.StreamObserver;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.core.streams.WriteStream;
+
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+/**
+ * @author Rogelio Orts
+ * @author Eduard Català
+ */
+public final class ClientCalls {
+
+  private ClientCalls() {
+  }
+
+  public static <I, O> Future<O> oneToOne(I request, BiConsumer<I, StreamObserver<O>> delegate) {
+    Promise<O> promise = Promise.promise();
+    delegate.accept(request, toStreamObserver(promise));
+    return promise.future();
+  }
+
+  public static <I, O> ReadStream<O> oneToMany(I request, BiConsumer<I, StreamObserver<O>> delegate) {
+    StreamObserverReadStream<O> response = new StreamObserverReadStream<>();
+    delegate.accept(request, response);
+    return response;
+  }
+
+  public static <I, O> Future<O> manyToOne(Handler<WriteStream<I>> requestHandler, Function<StreamObserver<O>, StreamObserver<I>> delegate) {
+    Promise<O> promise = Promise.promise();
+    StreamObserver<I> request = delegate.apply(toStreamObserver(promise));
+    requestHandler.handle(new GrpcWriteStream(request));
+    return promise.future();
+  }
+
+  public static <I, O> ReadStream<O> manyToMany(Handler<WriteStream<I>> requestHandler, Function<StreamObserver<O>, StreamObserver<I>> delegate) {
+    StreamObserverReadStream<O> response = new StreamObserverReadStream<>();
+    StreamObserver<I> request = delegate.apply(response);
+    requestHandler.handle(new GrpcWriteStream(request));
+    return response;
+  }
+
+  private static <O> StreamObserver<O> toStreamObserver(Promise<O> promise) {
+    return new StreamObserver<O>() {
+      @Override
+      public void onNext(O tResponse) {
+        promise.complete(tResponse);
+      }
+
+      @Override
+      public void onError(Throwable throwable) {
+        promise.fail(throwable);
+      }
+
+      @Override
+      public void onCompleted() {
+        // Do nothing
+      }
+    };
+  }
+
+}

--- a/src/main/java/io/vertx/grpc/stub/GrpcWriteStream.java
+++ b/src/main/java/io/vertx/grpc/stub/GrpcWriteStream.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 Eclipse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vertx.grpc.stub;
+
+import io.grpc.stub.StreamObserver;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.streams.WriteStream;
+
+/**
+ *
+ * @author ecatala
+ */
+public class GrpcWriteStream<T> implements WriteStream<T> {
+
+  private final StreamObserver<T> observer;
+  private Handler<Throwable> errHandler;
+
+  public GrpcWriteStream(StreamObserver<T> observer) {
+    this.observer = observer;
+    this.errHandler = observer::onError;
+  }
+
+  @Override
+  public GrpcWriteStream<T> exceptionHandler(Handler<Throwable> hndlr) {
+    if (hndlr == null) {
+      this.errHandler = observer::onError;
+    } else {
+      this.errHandler = (Throwable t) -> {
+        observer.onError(t);
+        hndlr.handle(t);
+      };
+    }
+    return this;
+  }
+
+  @Override
+  public GrpcWriteStream<T> write(T data) {
+    observer.onNext(data);
+    return this;
+  }
+
+  @Override
+  public GrpcWriteStream<T> write(T data, Handler<AsyncResult<Void>> hndlr) {
+    observer.onNext(data);
+    hndlr.handle(Future.succeededFuture());
+    return this;
+  }
+
+  @Override
+  public void end() {
+    observer.onCompleted();
+  }
+
+  @Override
+  public void end(Handler<AsyncResult<Void>> hndlr) {
+    observer.onCompleted();
+    hndlr.handle(Future.succeededFuture());
+  }
+
+  @Override
+  public WriteStream<T> setWriteQueueMaxSize(int i) {
+    errHandler.handle(new RuntimeException("Unsupported Operation"));
+    return this;
+  }
+
+  @Override
+  public boolean writeQueueFull() {
+    return false;
+  }
+
+  @Override
+  public WriteStream<T> drainHandler(Handler<Void> hndlr) {
+    errHandler.handle(new RuntimeException("Unsupported Operation"));
+    return this;
+  }
+
+}

--- a/src/main/java/io/vertx/grpc/stub/ServerCalls.java
+++ b/src/main/java/io/vertx/grpc/stub/ServerCalls.java
@@ -1,0 +1,82 @@
+package io.vertx.grpc.stub;
+
+import io.grpc.Status;
+import io.grpc.StatusException;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.core.streams.WriteStream;
+
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+/**
+ * @author Rogelio Orts
+ * @author Eduard Català
+ */
+public final class ServerCalls {
+
+  private ServerCalls() {
+  }
+
+  public static <I, O> void oneToOne(I request, StreamObserver<O> response, Function<I, Future<O>> delegate) {
+    try {
+      Future<O> future = delegate.apply(request);
+
+      future.setHandler(res -> {
+        if (res.succeeded()) {
+          response.onNext(res.result());
+          response.onCompleted();
+        } else {
+          response.onError(prepareError(res.cause()));
+        }
+      });
+
+    } catch (Throwable throwable) {
+      response.onError(prepareError(throwable));
+    }
+  }
+
+  public static <I, O> void oneToMany(I request, StreamObserver<O> response, BiConsumer<I, WriteStream<O>> delegate) {
+    try {
+      GrpcWriteStream<O> responseWriteStream = new GrpcWriteStream<>(response);
+      delegate.accept(request, responseWriteStream);
+    } catch (Throwable throwable) {
+      response.onError(prepareError(throwable));
+    }
+  }
+
+  public static <I, O> StreamObserver<I> manyToOne(StreamObserver<O> response, Function<ReadStream<I>, Future<O>> delegate) {
+
+    StreamObserverReadStream<I> request = new StreamObserverReadStream<>();
+    Future<O> future = delegate.apply(request);
+    future.setHandler(res -> {
+      if (res.succeeded()) {
+        response.onNext(res.result());
+        response.onCompleted();
+      } else {
+        response.onError(prepareError(res.cause()));
+      }
+    });
+
+    return request;
+  }
+
+  public static <I, O> StreamObserver<I> manyToMany(StreamObserver<O> response, BiConsumer<ReadStream<I>, WriteStream<O>> delegate) {
+    StreamObserverReadStream<I> request = new StreamObserverReadStream<>();
+    GrpcWriteStream<O> responseStream = new GrpcWriteStream<>(response);
+    delegate.accept(request, responseStream);
+    return request;
+  }
+
+  private static Throwable prepareError(Throwable throwable) {
+    if (throwable instanceof StatusException || throwable instanceof StatusRuntimeException) {
+      return throwable;
+    } else {
+      return Status.fromThrowable(throwable).asException();
+    }
+  }
+
+}

--- a/src/main/java/io/vertx/grpc/stub/StreamObserverReadStream.java
+++ b/src/main/java/io/vertx/grpc/stub/StreamObserverReadStream.java
@@ -1,0 +1,76 @@
+package io.vertx.grpc.stub;
+
+import io.grpc.stub.StreamObserver;
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.Handler;
+import io.vertx.core.streams.ReadStream;
+
+/**
+ * @author Rogelio Orts
+ */
+class StreamObserverReadStream<T> implements StreamObserver<T>, ReadStream<T> {
+
+  private Handler<Throwable> exceptionHandler;
+
+  private Handler<T> handler;
+
+  private Handler<Void> endHandler;
+
+  @Override
+  public void onNext(T t) {
+    if (handler != null) {
+      handler.handle(t);
+    }
+  }
+
+  @Override
+  public void onError(Throwable throwable) {
+    if (exceptionHandler != null) {
+      exceptionHandler.handle(throwable);
+    }
+  }
+
+  @Override
+  public void onCompleted() {
+    if (endHandler != null) {
+      endHandler.handle(null);
+    }
+  }
+
+  @Override
+  public ReadStream<T> exceptionHandler(Handler<Throwable> handler) {
+    this.exceptionHandler = handler;
+
+    return this;
+  }
+
+  @Override
+  public ReadStream<T> handler(@Nullable Handler<T> handler) {
+    this.handler = handler;
+
+    return this;
+  }
+
+  @Override
+  public ReadStream<T> pause() {
+    return this;
+  }
+
+  @Override
+  public ReadStream<T> resume() {
+    return this;
+  }
+
+  @Override
+  public ReadStream<T> fetch(long l) {
+    return this;
+  }
+
+  @Override
+  public ReadStream<T> endHandler(@Nullable Handler<Void> handler) {
+    this.endHandler = handler;
+
+    return this;
+  }
+
+}


### PR DESCRIPTION
Motivation:

Backport requires stub helpers from 4.0 branch needed to be present when using the new compiler on a 3.x project.