### PR TITLE
Issues/72

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,8 @@ insert_final_newline = true
 
 [Makefile]
 indent_style = tab
+
+[**/examples/**.java]
+# 84 looks like a odd number, however
+# it accounts for 4 spaces (class and example method indentation)
+max_line_length = 84

--- a/vertx-grpc-protoc-plugin/src/main/java/io/vertx/grpc/protoc/plugin/VertxGrpcGenerator.java
+++ b/vertx-grpc-protoc-plugin/src/main/java/io/vertx/grpc/protoc/plugin/VertxGrpcGenerator.java
@@ -228,7 +228,7 @@ public class VertxGrpcGenerator extends Generator {
   /**
    * Template class for proto RPC objects.
    */
-  private class MethodContext {
+  private static class MethodContext {
     // CHECKSTYLE DISABLE VisibilityModifier FOR 10 LINES
     public String methodName;
     public String inputType;

--- a/vertx-grpc-protoc-plugin/src/main/resources/VertxStub.mustache
+++ b/vertx-grpc-protoc-plugin/src/main/resources/VertxStub.mustache
@@ -18,27 +18,27 @@ comments = "Source: {{protoName}}")
 public final class {{className}} {
     private {{className}}() {}
 
-    public static Vertx{{serviceName}}Stub newVertxStub(io.grpc.Channel channel) {
-        return new Vertx{{serviceName}}Stub(channel);
+    public static {{serviceName}}VertxStub newVertxStub(io.grpc.Channel channel) {
+        return new {{serviceName}}VertxStub(channel);
     }
 
     {{#javaDoc}}{{{javaDoc}}}{{/javaDoc}}
-    public static final class Vertx{{serviceName}}Stub extends io.grpc.stub.AbstractStub<Vertx{{serviceName}}Stub> {
+    public static final class {{serviceName}}VertxStub extends io.grpc.stub.AbstractStub<{{serviceName}}VertxStub> {
         private {{serviceName}}Grpc.{{serviceName}}Stub delegateStub;
 
-        private Vertx{{serviceName}}Stub(io.grpc.Channel channel) {
+        private {{serviceName}}VertxStub(io.grpc.Channel channel) {
             super(channel);
             delegateStub = {{serviceName}}Grpc.newStub(channel);
         }
 
-        private Vertx{{serviceName}}Stub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+        private {{serviceName}}VertxStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
             super(channel, callOptions);
             delegateStub = {{serviceName}}Grpc.newStub(channel).build(channel, callOptions);
         }
 
         @Override
-        protected Vertx{{serviceName}}Stub build(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
-            return new Vertx{{serviceName}}Stub(channel, callOptions);
+        protected {{serviceName}}VertxStub build(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new {{serviceName}}VertxStub(channel, callOptions);
         }
 
         {{#unaryUnaryMethods}}
@@ -71,7 +71,7 @@ public final class {{className}} {
     }
 
     {{#javaDoc}}{{{javaDoc}}}{{/javaDoc}}
-    public static abstract class {{serviceName}}ImplBase implements io.grpc.BindableService {
+    public static abstract class {{serviceName}}VertxImplBase implements io.grpc.BindableService {
 
         private String compression;
 
@@ -80,7 +80,7 @@ public final class {{className}} {
          *
          * @param compression the compression, e.g {@code gzip}
          */
-        public {{serviceName}}ImplBase withCompression(String compression) {
+        public {{serviceName}}VertxImplBase withCompression(String compression) {
             this.compression = compression;
             return this;
         }
@@ -117,7 +117,7 @@ public final class {{className}} {
             return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
                     {{#methods}}
                     .addMethod(
-                            {{packageName}}.{{serviceName}}Grpc.get{{methodNamePascalCase}}Method(),
+                            {{packageName}}.{{serviceName}}Grpc.{{methodNameGetter}}(),
                             {{grpcCallsMethodName}}(
                                     new MethodHandlers<
                                             {{inputType}},
@@ -138,11 +138,11 @@ public final class {{className}} {
             io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
             io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
 
-        private final {{serviceName}}ImplBase serviceImpl;
+        private final {{serviceName}}VertxImplBase serviceImpl;
         private final int methodId;
         private final String compression;
 
-        MethodHandlers({{serviceName}}ImplBase serviceImpl, int methodId, String compression) {
+        MethodHandlers({{serviceName}}VertxImplBase serviceImpl, int methodId, String compression) {
             this.serviceImpl = serviceImpl;
             this.methodId = methodId;
             this.compression = compression;

--- a/vertx-grpc/src/main/java/examples/Examples.java
+++ b/vertx-grpc/src/main/java/examples/Examples.java
@@ -21,8 +21,14 @@ public class Examples {
     // The rcp service
     GreeterGrpc.GreeterImplBase service = new GreeterGrpc.GreeterImplBase() {
       @Override
-      public void sayHello(HelloRequest request, StreamObserver<HelloReply> responseObserver) {
-        responseObserver.onNext(HelloReply.newBuilder().setMessage(request.getName()).build());
+      public void sayHello(
+        HelloRequest request,
+        StreamObserver<HelloReply> responseObserver) {
+
+        responseObserver.onNext(
+          HelloReply.newBuilder()
+            .setMessage(request.getName())
+            .build());
         responseObserver.onCompleted();
       }
     };
@@ -41,21 +47,34 @@ public class Examples {
 
   public void vertxSimpleServer(Vertx vertx) throws Exception {
     // The rcp service
-    VertxGreeterGrpc.GreeterImplBase service = new VertxGreeterGrpc.GreeterImplBase() {
-      @Override
-      public Future<HelloReply> sayHello(HelloRequest request) {
-        return Future.succeededFuture(HelloReply.newBuilder().setMessage(request.getName()).build());
-      }
-    };
+    VertxGreeterGrpc.GreeterImplBase service =
+      new VertxGreeterGrpc.GreeterImplBase() {
+        @Override
+        public Future<HelloReply> sayHello(HelloRequest request) {
+          return Future.succeededFuture(
+            HelloReply.newBuilder()
+              .setMessage(request.getName())
+              .build());
+        }
+      };
   }
 
   public void serverWithCompression(Vertx vertx) {
     // The rcp service
     GreeterGrpc.GreeterImplBase service = new GreeterGrpc.GreeterImplBase() {
       @Override
-      public void sayHello(HelloRequest request, StreamObserver<HelloReply> responseObserver) {
-        ((ServerCallStreamObserver) responseObserver).setCompression("gzip");
-        responseObserver.onNext(HelloReply.newBuilder().setMessage(request.getName()).build());
+      public void sayHello(
+        HelloRequest request,
+        StreamObserver<HelloReply> responseObserver) {
+
+        ((ServerCallStreamObserver) responseObserver)
+          .setCompression("gzip");
+
+        responseObserver.onNext(
+          HelloReply.newBuilder()
+            .setMessage(request.getName())
+            .build());
+
         responseObserver.onCompleted();
       }
     };
@@ -63,13 +82,17 @@ public class Examples {
 
   public void vertxServerWithCompression() {
     // The rcp service
-    VertxGreeterGrpc.GreeterImplBase service = new VertxGreeterGrpc.GreeterImplBase() {
-      @Override
-      public Future<HelloReply> sayHello(HelloRequest request) {
-        return Future.succeededFuture(HelloReply.newBuilder().setMessage(request.getName()).build());
+    VertxGreeterGrpc.GreeterImplBase service =
+      new VertxGreeterGrpc.GreeterImplBase() {
+        @Override
+        public Future<HelloReply> sayHello(HelloRequest request) {
+          return Future.succeededFuture(
+            HelloReply.newBuilder()
+              .setMessage(request.getName())
+              .build());
+        }
       }
-    }
-    .withCompression("gzip");
+        .withCompression("gzip");
   }
 
   public void connectClient(Vertx vertx) {
@@ -90,17 +113,20 @@ public class Examples {
     // Call the remote service
     stub.sayHello(request, new StreamObserver<HelloReply>() {
       private HelloReply helloReply;
+
       @Override
       public void onNext(HelloReply helloReply) {
         this.helloReply = helloReply;
       }
+
       @Override
       public void onError(Throwable throwable) {
         System.out.println("Coult not reach server " + throwable.getMessage());
       }
+
       @Override
       public void onCompleted() {
-        System.out.println("Got the server response: " +helloReply.getMessage());
+        System.out.println("Got the server response: " + helloReply.getMessage());
       }
     });
   }
@@ -115,14 +141,15 @@ public class Examples {
     // Listen to completion events
     future
       .onSuccess(helloReply -> {
-      System.out.println("Got the server response: " + helloReply.getMessage());
-    }).onFailure(err -> {
+        System.out.println("Got the server response: " + helloReply.getMessage());
+      }).onFailure(err -> {
       System.out.println("Coult not reach server " + err);
     });
   }
 
   public void clientWithCompression(ManagedChannel channel) {
-    // Get a stub to use for interacting with the remote service with message compression
+    // Get a stub to use for interacting with the
+    // remote service with message compression
     GreeterGrpc.GreeterStub stub = GreeterGrpc
       .newStub(channel)
       .withCompression("gzip");
@@ -130,12 +157,12 @@ public class Examples {
 
   public void sslServer(Vertx vertx) {
     VertxServerBuilder builder = VertxServerBuilder.forPort(vertx, 8080)
-        .useSsl(options -> options
-            .setSsl(true)
-            .setUseAlpn(true)
-            .setKeyStoreOptions(new JksOptions()
-                .setPath("server-keystore.jks")
-                .setPassword("secret")));
+      .useSsl(options -> options
+        .setSsl(true)
+        .setUseAlpn(true)
+        .setKeyStoreOptions(new JksOptions()
+          .setPath("server-keystore.jks")
+          .setPassword("secret")));
   }
 
   public void serverScaling(Vertx vertx) {
@@ -147,8 +174,15 @@ public class Examples {
 
         BindableService service = new GreeterGrpc.GreeterImplBase() {
           @Override
-          public void sayHello(HelloRequest request, StreamObserver<HelloReply> responseObserver) {
-            responseObserver.onNext(HelloReply.newBuilder().setMessage(request.getName()).build());
+          public void sayHello(
+            HelloRequest request,
+            StreamObserver<HelloReply> responseObserver) {
+
+            responseObserver.onNext(
+              HelloReply.newBuilder()
+                .setMessage(request.getName())
+                .build());
+
             responseObserver.onCompleted();
           }
         };
@@ -170,14 +204,14 @@ public class Examples {
 
   public void sslClient(Vertx vertx) {
     ManagedChannel channel = VertxChannelBuilder.
-        forAddress(vertx, "localhost", 8080)
-        .useSsl(options -> options
-            .setSsl(true)
-            .setUseAlpn(true)
-            .setTrustStoreOptions(new JksOptions()
-                .setPath("client-truststore.jks")
-                .setPassword("secret")))
-        .build();
+      forAddress(vertx, "localhost", 8080)
+      .useSsl(options -> options
+        .setSsl(true)
+        .setUseAlpn(true)
+        .setTrustStoreOptions(new JksOptions()
+          .setPath("client-truststore.jks")
+          .setPassword("secret")))
+      .build();
   }
 
   public void blockingInterceptor() {
@@ -193,7 +227,7 @@ public class Examples {
   }
 
   public <MyInterceptor extends ServerInterceptor> void nonblockingInterceptorUsage(
-    MyInterceptor myInterceptor, Vertx vertx, BindableService service)  throws Exception {
+    MyInterceptor myInterceptor, Vertx vertx, BindableService service) {
     VertxServer rpcServer = VertxServerBuilder
       .forAddress(vertx, "my.host", 8080)
       .addService(ServerInterceptors.intercept(service, myInterceptor))
@@ -201,9 +235,13 @@ public class Examples {
   }
 
   public <MyInterceptor extends ServerInterceptor> void blockingInterceptorUsage(
-    MyInterceptor myInterceptor, Vertx vertx, BindableService service)  throws Exception {
+    MyInterceptor myInterceptor,
+    Vertx vertx,
+    BindableService service) throws Exception {
+
     // wrap interceptor to execute on worker thread instead of event loop
-    ServerInterceptor wrapped = BlockingServerInterceptor.wrap(vertx, myInterceptor);
+    ServerInterceptor wrapped =
+      BlockingServerInterceptor.wrap(vertx, myInterceptor);
 
     // Create the server
     VertxServer rpcServer = VertxServerBuilder

--- a/vertx-grpc/src/main/java/examples/Examples.java
+++ b/vertx-grpc/src/main/java/examples/Examples.java
@@ -47,8 +47,8 @@ public class Examples {
 
   public void vertxSimpleServer(Vertx vertx) throws Exception {
     // The rcp service
-    VertxGreeterGrpc.GreeterImplBase service =
-      new VertxGreeterGrpc.GreeterImplBase() {
+    VertxGreeterGrpc.GreeterVertxImplBase service =
+      new VertxGreeterGrpc.GreeterVertxImplBase() {
         @Override
         public Future<HelloReply> sayHello(HelloRequest request) {
           return Future.succeededFuture(
@@ -82,8 +82,8 @@ public class Examples {
 
   public void vertxServerWithCompression() {
     // The rcp service
-    VertxGreeterGrpc.GreeterImplBase service =
-      new VertxGreeterGrpc.GreeterImplBase() {
+    VertxGreeterGrpc.GreeterVertxImplBase service =
+      new VertxGreeterGrpc.GreeterVertxImplBase() {
         @Override
         public Future<HelloReply> sayHello(HelloRequest request) {
           return Future.succeededFuture(
@@ -131,7 +131,7 @@ public class Examples {
     });
   }
 
-  public void vertxSimpleClient(VertxGreeterGrpc.VertxGreeterStub stub) {
+  public void vertxSimpleClient(VertxGreeterGrpc.GreeterVertxStub stub) {
     // Make a request
     HelloRequest request = HelloRequest.newBuilder().setName("Julien").build();
 

--- a/vertx-grpc/src/main/java/examples/VertxGreeterGrpc.java
+++ b/vertx-grpc/src/main/java/examples/VertxGreeterGrpc.java
@@ -13,8 +13,8 @@ comments = "Source: helloworld.proto")
 public final class VertxGreeterGrpc {
     private VertxGreeterGrpc() {}
 
-    public static VertxGreeterStub newVertxStub(io.grpc.Channel channel) {
-        return new VertxGreeterStub(channel);
+    public static GreeterVertxStub newVertxStub(io.grpc.Channel channel) {
+        return new GreeterVertxStub(channel);
     }
 
     /**
@@ -22,22 +22,22 @@ public final class VertxGreeterGrpc {
      *  The greeting service definition.
      * </pre>
      */
-    public static final class VertxGreeterStub extends io.grpc.stub.AbstractStub<VertxGreeterStub> {
+    public static final class GreeterVertxStub extends io.grpc.stub.AbstractStub<GreeterVertxStub> {
         private GreeterGrpc.GreeterStub delegateStub;
 
-        private VertxGreeterStub(io.grpc.Channel channel) {
+        private GreeterVertxStub(io.grpc.Channel channel) {
             super(channel);
             delegateStub = GreeterGrpc.newStub(channel);
         }
 
-        private VertxGreeterStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+        private GreeterVertxStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
             super(channel, callOptions);
             delegateStub = GreeterGrpc.newStub(channel).build(channel, callOptions);
         }
 
         @Override
-        protected VertxGreeterStub build(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
-            return new VertxGreeterStub(channel, callOptions);
+        protected GreeterVertxStub build(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new GreeterVertxStub(channel, callOptions);
         }
 
         /**
@@ -56,7 +56,7 @@ public final class VertxGreeterGrpc {
      *  The greeting service definition.
      * </pre>
      */
-    public static abstract class GreeterImplBase implements io.grpc.BindableService {
+    public static abstract class GreeterVertxImplBase implements io.grpc.BindableService {
 
         private String compression;
 
@@ -65,7 +65,7 @@ public final class VertxGreeterGrpc {
          *
          * @param compression the compression, e.g {@code gzip}
          */
-        public GreeterImplBase withCompression(String compression) {
+        public GreeterVertxImplBase withCompression(String compression) {
             this.compression = compression;
             return this;
         }
@@ -100,11 +100,11 @@ public final class VertxGreeterGrpc {
             io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
             io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
 
-        private final GreeterImplBase serviceImpl;
+        private final GreeterVertxImplBase serviceImpl;
         private final int methodId;
         private final String compression;
 
-        MethodHandlers(GreeterImplBase serviceImpl, int methodId, String compression) {
+        MethodHandlers(GreeterVertxImplBase serviceImpl, int methodId, String compression) {
             this.serviceImpl = serviceImpl;
             this.methodId = methodId;
             this.compression = compression;

--- a/vertx-grpc/src/main/java/io/vertx/grpc/stub/ClientCalls.java
+++ b/vertx-grpc/src/main/java/io/vertx/grpc/stub/ClientCalls.java
@@ -34,14 +34,14 @@ public final class ClientCalls {
   public static <I, O> Future<O> manyToOne(Handler<WriteStream<I>> requestHandler, Function<StreamObserver<O>, StreamObserver<I>> delegate) {
     Promise<O> promise = Promise.promise();
     StreamObserver<I> request = delegate.apply(toStreamObserver(promise));
-    requestHandler.handle(new GrpcWriteStream(request));
+    requestHandler.handle(new GrpcWriteStream<>(request));
     return promise.future();
   }
 
   public static <I, O> ReadStream<O> manyToMany(Handler<WriteStream<I>> requestHandler, Function<StreamObserver<O>, StreamObserver<I>> delegate) {
     StreamObserverReadStream<O> response = new StreamObserverReadStream<>();
     StreamObserver<I> request = delegate.apply(response);
-    requestHandler.handle(new GrpcWriteStream(request));
+    requestHandler.handle(new GrpcWriteStream<>(request));
     return response;
   }
 

--- a/vertx-grpc/src/main/java/io/vertx/grpc/stub/ServerCalls.java
+++ b/vertx-grpc/src/main/java/io/vertx/grpc/stub/ServerCalls.java
@@ -6,7 +6,6 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
 

--- a/vertx-grpc/src/test/java/io/vertx/ext/grpc/CommandDecoratorTest.java
+++ b/vertx-grpc/src/test/java/io/vertx/ext/grpc/CommandDecoratorTest.java
@@ -37,7 +37,7 @@ public class CommandDecoratorTest extends GrpcTestBase {
         .start(completionHandler);*/
         server = VertxServerBuilder.forPort(vertx, port)
           .commandDecorator(decorator)
-          .addService(new VertxGreeterGrpc.GreeterImplBase() {
+          .addService(new VertxGreeterGrpc.GreeterVertxImplBase() {
             @Override
             public Future<HelloReply> sayHello(HelloRequest request) {
               ctx.assertEquals(serverCtx, Vertx.currentContext());
@@ -69,7 +69,7 @@ public class CommandDecoratorTest extends GrpcTestBase {
       ManagedChannel channel = VertxChannelBuilder.forAddress(vertx, "localhost", port)
         .usePlaintext(true)
         .build();
-      VertxGreeterGrpc.VertxGreeterStub stub = VertxGreeterGrpc.newVertxStub(channel);
+      VertxGreeterGrpc.GreeterVertxStub stub = VertxGreeterGrpc.newVertxStub(channel);
       HelloRequest request = HelloRequest.newBuilder().setName("Julien").build();
       stub.sayHello(request).onComplete(ar -> {
         if (ar.succeeded()) {

--- a/vertx-grpc/src/test/java/io/vertx/ext/grpc/CommandDecoratorTest.java
+++ b/vertx-grpc/src/test/java/io/vertx/ext/grpc/CommandDecoratorTest.java
@@ -4,6 +4,7 @@ import examples.HelloReply;
 import examples.HelloRequest;
 import examples.VertxGreeterGrpc;
 import io.grpc.ManagedChannel;
+import io.grpc.netty.NegotiationType;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;

--- a/vertx-grpc/src/test/java/io/vertx/ext/grpc/GoogleTest.java
+++ b/vertx-grpc/src/test/java/io/vertx/ext/grpc/GoogleTest.java
@@ -29,7 +29,7 @@ public class GoogleTest extends GrpcTestBase {
 
   private ManagedChannel channel;
 
-  private VertxTestServiceGrpc.VertxTestServiceStub buildStub() {
+  private VertxTestServiceGrpc.TestServiceVertxStub buildStub() {
     channel = VertxChannelBuilder.forAddress(vertx, "localhost", port).usePlaintext(true).build();
     return VertxTestServiceGrpc.newVertxStub(channel);
   }
@@ -45,7 +45,7 @@ public class GoogleTest extends GrpcTestBase {
   @Test
   public void emptyCallTest(TestContext will) {
     Async test = will.async();
-    startServer(new VertxTestServiceGrpc.TestServiceImplBase() {
+    startServer(new VertxTestServiceGrpc.TestServiceVertxImplBase() {
       @Override
       public Future<Empty> emptyCall(Empty request) {
         will.assertNotNull(request);
@@ -68,7 +68,7 @@ public class GoogleTest extends GrpcTestBase {
   @Test
   public void emptyUnaryTest(TestContext will) {
     Async test = will.async();
-    startServer(new VertxTestServiceGrpc.TestServiceImplBase() {
+    startServer(new VertxTestServiceGrpc.TestServiceVertxImplBase() {
       @Override
       public Future<SimpleResponse> unaryCall(SimpleRequest request) {
         will.assertNotNull(request);
@@ -91,7 +91,7 @@ public class GoogleTest extends GrpcTestBase {
   @Test
   public void streamingOutputCallTest(TestContext will) {
     Async test = will.async();
-    startServer(new VertxTestServiceGrpc.TestServiceImplBase() {
+    startServer(new VertxTestServiceGrpc.TestServiceVertxImplBase() {
       @Override
       public void streamingOutputCall(StreamingOutputCallRequest request, WriteStream<StreamingOutputCallResponse> response) {
         will.assertNotNull(request);
@@ -121,7 +121,7 @@ public class GoogleTest extends GrpcTestBase {
     final Async test = will.async();
     final AtomicInteger cnt = new AtomicInteger();
 
-    startServer(new VertxTestServiceGrpc.TestServiceImplBase() {
+    startServer(new VertxTestServiceGrpc.TestServiceVertxImplBase() {
       @Override
       public Future<StreamingInputCallResponse> streamingInputCall(ReadStream<StreamingInputCallRequest> request) {
         will.assertNotNull(request);
@@ -156,7 +156,7 @@ public class GoogleTest extends GrpcTestBase {
   public void fullDuplexCallTest(TestContext will) {
     final Async test = will.async();
 
-    startServer(new VertxTestServiceGrpc.TestServiceImplBase() {
+    startServer(new VertxTestServiceGrpc.TestServiceVertxImplBase() {
       final AtomicInteger cnt = new AtomicInteger();
 
       @Override
@@ -196,7 +196,7 @@ public class GoogleTest extends GrpcTestBase {
   @Test
   public void halfDuplexCallTest(TestContext will) throws Exception {
     Async test = will.async();
-    startServer(new VertxTestServiceGrpc.TestServiceImplBase() {
+    startServer(new VertxTestServiceGrpc.TestServiceVertxImplBase() {
       final AtomicInteger cnt = new AtomicInteger();
 
       @Override
@@ -242,7 +242,7 @@ public class GoogleTest extends GrpcTestBase {
   @Test
   public void unimplementedCallTest(TestContext will) {
     Async test = will.async();
-    startServer(new VertxTestServiceGrpc.TestServiceImplBase() {
+    startServer(new VertxTestServiceGrpc.TestServiceVertxImplBase() {
       // The test server will not implement this method. It will be used
       // to test the behavior when clients call unimplemented methods.
     }, will.asyncAssertSuccess(v -> {

--- a/vertx-grpc/src/test/java/io/vertx/ext/grpc/RpcTest.java
+++ b/vertx-grpc/src/test/java/io/vertx/ext/grpc/RpcTest.java
@@ -19,7 +19,6 @@ import io.vertx.core.streams.WriteStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;

--- a/vertx-grpc/src/test/java/io/vertx/ext/grpc/RpcTest.java
+++ b/vertx-grpc/src/test/java/io/vertx/ext/grpc/RpcTest.java
@@ -46,7 +46,7 @@ public class RpcTest extends GrpcTestBase {
   public void testSimple(TestContext ctx) {
     Async started = ctx.async();
     Context serverCtx = vertx.getOrCreateContext();
-    serverCtx.runOnContext(v1 -> startServer(new VertxGreeterGrpc.GreeterImplBase() {
+    serverCtx.runOnContext(v1 -> startServer(new VertxGreeterGrpc.GreeterVertxImplBase() {
       @Override
       public Future<HelloReply> sayHello(HelloRequest request) {
         ctx.assertEquals(serverCtx, Vertx.currentContext());
@@ -62,7 +62,7 @@ public class RpcTest extends GrpcTestBase {
       channel = VertxChannelBuilder.forAddress(vertx, "localhost", port)
        .usePlaintext(true)
        .build();
-      VertxGreeterGrpc.VertxGreeterStub stub = VertxGreeterGrpc.newVertxStub(channel);
+      VertxGreeterGrpc.GreeterVertxStub stub = VertxGreeterGrpc.newVertxStub(channel);
       HelloRequest request = HelloRequest.newBuilder().setName("Julien").build();
       stub.sayHello(request).onComplete(ctx.asyncAssertSuccess(res -> {
         ctx.assertEquals(clientCtx, Vertx.currentContext());
@@ -89,7 +89,7 @@ public class RpcTest extends GrpcTestBase {
         return h.startCall(call, m);
       }
     };
-    BindableService service = new VertxGreeterGrpc.GreeterImplBase() {
+    BindableService service = new VertxGreeterGrpc.GreeterVertxImplBase() {
       @Override
       public Future<HelloReply> sayHello(HelloRequest request) {
 
@@ -102,7 +102,7 @@ public class RpcTest extends GrpcTestBase {
     channel = VertxChannelBuilder.forAddress(vertx, "localhost", port)
      .usePlaintext(true)
      .build();
-    VertxGreeterGrpc.VertxGreeterStub stub = VertxGreeterGrpc.newVertxStub(channel);
+    VertxGreeterGrpc.GreeterVertxStub stub = VertxGreeterGrpc.newVertxStub(channel);
     Arrays.asList("Julien", "Paulo").forEach(name -> {
       stub
         .sayHello(HelloRequest.newBuilder().setName(name).build())
@@ -125,7 +125,7 @@ public class RpcTest extends GrpcTestBase {
         throw new StatusRuntimeException(Status.ABORTED, md);
       }
     };
-    BindableService service = new VertxGreeterGrpc.GreeterImplBase() {
+    BindableService service = new VertxGreeterGrpc.GreeterVertxImplBase() {
       @Override
       public Future<HelloReply> sayHello(HelloRequest request) {
         return Future.succeededFuture(HelloReply.newBuilder().setMessage("Hello " + request.getName()).build());
@@ -147,7 +147,7 @@ public class RpcTest extends GrpcTestBase {
     channel = VertxChannelBuilder.forAddress(vertx, "localhost", port)
      .usePlaintext(true)
      .build();
-    VertxGreeterGrpc.VertxGreeterStub stub = VertxGreeterGrpc.newVertxStub(channel);
+    VertxGreeterGrpc.GreeterVertxStub stub = VertxGreeterGrpc.newVertxStub(channel);
     stub.sayHello(HelloRequest.newBuilder().setName("Julien").build()).onComplete(ctx.asyncAssertFailure(err -> {
       ctx.assertTrue(err instanceof StatusRuntimeException);
       StatusRuntimeException sre = (StatusRuntimeException) err;
@@ -162,7 +162,7 @@ public class RpcTest extends GrpcTestBase {
   public void testStreamSource(TestContext ctx) throws Exception {
     int numItems = 128;
     Async done = ctx.async();
-    startServer(new VertxStreamingGrpc.StreamingImplBase() {
+    startServer(new VertxStreamingGrpc.StreamingVertxImplBase() {
       @Override
       public void source(Empty request, WriteStream<Item> response) {
         new IterableReadStream<>(cnt -> Item.newBuilder().setValue("the-value-" + cnt).build(), numItems).pipeTo(response);
@@ -171,7 +171,7 @@ public class RpcTest extends GrpcTestBase {
     channel = VertxChannelBuilder.forAddress(vertx, "localhost", port)
      .usePlaintext(true)
      .build();
-    VertxStreamingGrpc.VertxStreamingStub stub = VertxStreamingGrpc.newVertxStub(channel);
+    VertxStreamingGrpc.StreamingVertxStub stub = VertxStreamingGrpc.newVertxStub(channel);
     final List<String> items = new ArrayList<>();
     stub.source(Empty.newBuilder().build())
      .endHandler(v -> {
@@ -187,7 +187,7 @@ public class RpcTest extends GrpcTestBase {
   public void testStreamSink(TestContext ctx) throws Exception {
     int numItems = 128;
     Async done = ctx.async();
-    startServer(new VertxStreamingGrpc.StreamingImplBase() {
+    startServer(new VertxStreamingGrpc.StreamingVertxImplBase() {
       @Override
       public Future<Empty> sink(ReadStream<Item> request) {
         List<String> items = new ArrayList<>();
@@ -208,7 +208,7 @@ public class RpcTest extends GrpcTestBase {
     channel = VertxChannelBuilder.forAddress(vertx, "localhost", port)
      .usePlaintext(true)
      .build();
-    VertxStreamingGrpc.VertxStreamingStub stub = VertxStreamingGrpc.newVertxStub(channel);
+    VertxStreamingGrpc.StreamingVertxStub stub = VertxStreamingGrpc.newVertxStub(channel);
     AtomicInteger count = new AtomicInteger(numItems);
 
     Handler<WriteStream<Item>> h = ws -> {
@@ -232,7 +232,7 @@ public class RpcTest extends GrpcTestBase {
   public void testStreamPipe(TestContext ctx) throws Exception {
     int numItems = 128;
     Async done = ctx.async();
-    startServer(new VertxStreamingGrpc.StreamingImplBase() {
+    startServer(new VertxStreamingGrpc.StreamingVertxImplBase() {
       @Override
       public void pipe(ReadStream<Item> request, WriteStream<Item> response) {
         request.pipeTo(response);
@@ -241,7 +241,7 @@ public class RpcTest extends GrpcTestBase {
     channel = VertxChannelBuilder.forAddress(vertx, "localhost", port)
      .usePlaintext(true)
      .build();
-    VertxStreamingGrpc.VertxStreamingStub stub = VertxStreamingGrpc.newVertxStub(channel);
+    VertxStreamingGrpc.StreamingVertxStub stub = VertxStreamingGrpc.newVertxStub(channel);
     final List<String> items = new ArrayList<>();
     AtomicInteger count = new AtomicInteger(numItems);
 
@@ -272,7 +272,7 @@ public class RpcTest extends GrpcTestBase {
   public void testRandomPort(TestContext ctx) throws Exception {
     Async started = ctx.async();
     port = 0;
-    startServer(new VertxGreeterGrpc.GreeterImplBase() {
+    startServer(new VertxGreeterGrpc.GreeterVertxImplBase() {
       @Override
       public Future<HelloReply> sayHello(HelloRequest request) {
         return Future.succeededFuture(HelloReply.newBuilder().setMessage("Hello " + request.getName()).build());
@@ -309,7 +309,7 @@ public class RpcTest extends GrpcTestBase {
       }
     };
 
-    VertxGreeterGrpc.GreeterImplBase service = new VertxGreeterGrpc.GreeterImplBase() {
+    VertxGreeterGrpc.GreeterVertxImplBase service = new VertxGreeterGrpc.GreeterVertxImplBase() {
       @Override
       public Future<HelloReply> sayHello(HelloRequest request) {
         return Future.succeededFuture(HelloReply.newBuilder().setMessage("Hello " + request.getName()).build());
@@ -321,7 +321,7 @@ public class RpcTest extends GrpcTestBase {
     channel = VertxChannelBuilder.forAddress(vertx, "localhost", port)
       .usePlaintext(true)
       .build();
-    VertxGreeterGrpc.VertxGreeterStub stub = VertxGreeterGrpc.newVertxStub(channel);
+    VertxGreeterGrpc.GreeterVertxStub stub = VertxGreeterGrpc.newVertxStub(channel);
     HelloRequest request = HelloRequest.newBuilder().setName("Julien").build();
     stub
       .withInterceptors(new ClientInterceptor() {

--- a/vertx-grpc/src/test/java/io/vertx/ext/grpc/SslTest.java
+++ b/vertx-grpc/src/test/java/io/vertx/ext/grpc/SslTest.java
@@ -100,7 +100,7 @@ public class SslTest extends GrpcTestBase {
     Async started = ctx.async();
     Context serverCtx = vertx.getOrCreateContext();
     serverCtx.runOnContext(v -> {
-      VertxGreeterGrpc.GreeterImplBase service = new VertxGreeterGrpc.GreeterImplBase() {
+      VertxGreeterGrpc.GreeterVertxImplBase service = new VertxGreeterGrpc.GreeterVertxImplBase() {
         @Override
         public Future<HelloReply> sayHello(HelloRequest request) {
           ctx.assertEquals(serverCtx, Vertx.currentContext());
@@ -124,7 +124,7 @@ public class SslTest extends GrpcTestBase {
             .useSsl(clientSslBuilder)
             .build();
         channelRef.set(channel);
-        VertxGreeterGrpc.VertxGreeterStub stub = VertxGreeterGrpc.newVertxStub(channel);
+        VertxGreeterGrpc.GreeterVertxStub stub = VertxGreeterGrpc.newVertxStub(channel);
         HelloRequest request = HelloRequest.newBuilder().setName("Julien").build();
         Future<HelloReply> fut = stub.sayHello(request);
         if (pass) {

--- a/vertx-grpc/src/test/java/io/vertx/ext/grpc/VerticleTest.java
+++ b/vertx-grpc/src/test/java/io/vertx/ext/grpc/VerticleTest.java
@@ -48,7 +48,7 @@ public class VerticleTest {
 
     private final int port;
     private volatile VertxServer server;
-    private VertxGreeterGrpc.GreeterImplBase service;
+    private VertxGreeterGrpc.GreeterVertxImplBase service;
 
     public GrpcVerticle(int port) {
       this.port = port;
@@ -60,7 +60,7 @@ public class VerticleTest {
 
     @Override
     public void start(Promise<Void> startFuture) throws Exception {
-      service = new VertxGreeterGrpc.GreeterImplBase() {
+      service = new VertxGreeterGrpc.GreeterVertxImplBase() {
         @Override
         public Future<HelloReply> sayHello(HelloRequest request) {
           threads.add(Thread.currentThread());
@@ -98,7 +98,7 @@ public class VerticleTest {
             .usePlaintext(true)
             .build();
         toClose.add(channel);
-        VertxGreeterGrpc.VertxGreeterStub stub = VertxGreeterGrpc.newVertxStub(channel);
+        VertxGreeterGrpc.GreeterVertxStub stub = VertxGreeterGrpc.newVertxStub(channel);
         HelloRequest request = HelloRequest.newBuilder().setName("Julien").build();
         stub.sayHello(request).onComplete(ctx.asyncAssertSuccess(res -> {
           ctx.assertEquals("Hello Julien", res.getMessage());
@@ -126,7 +126,7 @@ public class VerticleTest {
         .usePlaintext(true)
         .build();
     try {
-      VertxGreeterGrpc.VertxGreeterStub blockingStub = VertxGreeterGrpc.newVertxStub(channel);
+      VertxGreeterGrpc.GreeterVertxStub blockingStub = VertxGreeterGrpc.newVertxStub(channel);
       HelloRequest request = HelloRequest.newBuilder().setName("Julien").build();
       blockingStub.sayHello(request).onComplete(ctx.asyncAssertFailure(err -> async.complete()));
       async.awaitSuccess(20000);

--- a/vertx-grpc/src/test/java/io/vertx/ext/grpc/utils/IterableReadStream.java
+++ b/vertx-grpc/src/test/java/io/vertx/ext/grpc/utils/IterableReadStream.java
@@ -4,7 +4,6 @@ import io.vertx.core.Handler;
 import io.vertx.core.streams.ReadStream;
 
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 public class IterableReadStream<T> extends BaseReadStream<T> {
 


### PR DESCRIPTION
Motivation:

To reduce the breakage when migrating to 4.0.0 this PR aligns the method generation naming style to the old C++ generator.

Fixes #72 