### PR TITLE
Made tests async to avoid race issues

### DIFF
--- a/vertx-grpc-protoc-plugin/src/main/java/io/vertx/grpc/protoc/plugin/VertxGrpcGenerator.java
+++ b/vertx-grpc-protoc-plugin/src/main/java/io/vertx/grpc/protoc/plugin/VertxGrpcGenerator.java
@@ -288,7 +288,7 @@ public class VertxGrpcGenerator extends Generator {
   /**
    * Template class for proto Service objects.
    */
-  private class ServiceContext {
+  private static class ServiceContext {
     // CHECKSTYLE DISABLE VisibilityModifier FOR 8 LINES
     public String fileName;
     public String protoName;
@@ -297,7 +297,7 @@ public class VertxGrpcGenerator extends Generator {
     public String serviceName;
     public boolean deprecated;
     public String javaDoc;
-    public List<MethodContext> methods = new ArrayList<>();
+    public final List<MethodContext> methods = new ArrayList<>();
 
     public List<MethodContext> unaryUnaryMethods() {
       return methods.stream().filter(m -> !m.isManyInput && !m.isManyOutput).collect(Collectors.toList());

--- a/vertx-grpc/src/main/java/examples/Examples.java
+++ b/vertx-grpc/src/main/java/examples/Examples.java
@@ -140,11 +140,7 @@ public class Examples {
 
     // Listen to completion events
     future
-      .onSuccess(helloReply -> {
-        System.out.println("Got the server response: " + helloReply.getMessage());
-      }).onFailure(err -> {
-      System.out.println("Coult not reach server " + err);
-    });
+      .onSuccess(helloReply -> System.out.println("Got the server response: " + helloReply.getMessage())).onFailure(err -> System.out.println("Coult not reach server " + err));
   }
 
   public void clientWithCompression(ManagedChannel channel) {

--- a/vertx-grpc/src/main/java/io/vertx/grpc/BlockingServerInterceptor.java
+++ b/vertx-grpc/src/main/java/io/vertx/grpc/BlockingServerInterceptor.java
@@ -54,7 +54,7 @@ public class BlockingServerInterceptor implements ServerInterceptor {
    */
   private static class AsyncListener<ReqT> extends ServerCall.Listener<ReqT> {
     private ServerCall.Listener<ReqT> delegate;
-    private List<Consumer<ServerCall.Listener<ReqT>>> incomingEvents = new LinkedList<>();
+    private final List<Consumer<ServerCall.Listener<ReqT>>> incomingEvents = new LinkedList<>();
 
     void setDelegate(ServerCall.Listener<ReqT> delegate) {
       this.delegate = delegate;

--- a/vertx-grpc/src/main/java/io/vertx/grpc/VertxChannelBuilder.java
+++ b/vertx-grpc/src/main/java/io/vertx/grpc/VertxChannelBuilder.java
@@ -44,8 +44,8 @@ public class VertxChannelBuilder extends ManagedChannelBuilder<VertxChannelBuild
 
   private final Vertx vertx;
   private final NettyChannelBuilder builder;
-  private ContextInternal context;
-  private HttpClientOptions options = new HttpClientOptions();
+  private final ContextInternal context;
+  private final HttpClientOptions options = new HttpClientOptions();
 
   private VertxChannelBuilder(Vertx vertx, String host, int port) {
     this(vertx, GrpcUtil.authorityFromHostAndPort(host, port));

--- a/vertx-grpc/src/main/java/io/vertx/grpc/VertxServer.java
+++ b/vertx-grpc/src/main/java/io/vertx/grpc/VertxServer.java
@@ -71,13 +71,9 @@ public class VertxServer extends Server {
 
       this.id = id;
       this.options = options;
-      Executor executor = command -> {
-        contextLocal.get().get(0).dispatch(event -> command.run());
-      };
+      Executor executor = command -> contextLocal.get().get(0).dispatch(event -> command.run());
       if (commandDecorator != null) {
-        executor = command -> {
-          contextLocal.get().get(0).dispatch(event -> commandDecorator.accept(command));
-        };
+        executor = command -> contextLocal.get().get(0).dispatch(event -> commandDecorator.accept(command));
       }
       this.server = builder
           .executor(executor)
@@ -162,7 +158,7 @@ public class VertxServer extends Server {
     }
     actual.start(context, ar1 -> {
       if (ar1.succeeded()) {
-        hook = ar2 -> shutdown(ar2);
+        hook = this::shutdown;
         context.addCloseHook(hook);
       }
       completionHandler.handle(ar1);

--- a/vertx-grpc/src/main/java/io/vertx/grpc/VertxServerBuilder.java
+++ b/vertx-grpc/src/main/java/io/vertx/grpc/VertxServerBuilder.java
@@ -36,9 +36,9 @@ public class VertxServerBuilder extends ServerBuilder<VertxServerBuilder> {
   }
 
   private final ServerID id;
-  private VertxInternal vertx;
-  private NettyServerBuilder builder;
-  private HttpServerOptions options = new HttpServerOptions();
+  private final VertxInternal vertx;
+  private final NettyServerBuilder builder;
+  private final HttpServerOptions options = new HttpServerOptions();
   private Consumer<Runnable> commandDecorator;
 
   private VertxServerBuilder(Vertx vertx, int port) {

--- a/vertx-grpc/src/test/java/io/vertx/ext/grpc/CommandDecoratorTest.java
+++ b/vertx-grpc/src/test/java/io/vertx/ext/grpc/CommandDecoratorTest.java
@@ -60,7 +60,7 @@ public class CommandDecoratorTest extends GrpcTestBase {
             if (!decorator.invoked) {
               should.fail("Command Decorator was not invoked");
             }
-            channel.shutdown();
+            channel.shutdownNow();
             test.complete();
           });
       } else {

--- a/vertx-grpc/src/test/java/io/vertx/ext/grpc/GrpcTestBase.java
+++ b/vertx-grpc/src/test/java/io/vertx/ext/grpc/GrpcTestBase.java
@@ -31,7 +31,7 @@ public abstract class GrpcTestBase {
 
   @Before
   public void setUp() {
-    port = 50051;
+    port = 8080;
     vertx = rule.vertx();
   }
 

--- a/vertx-grpc/src/test/java/io/vertx/ext/grpc/VerticleTest.java
+++ b/vertx-grpc/src/test/java/io/vertx/ext/grpc/VerticleTest.java
@@ -48,7 +48,6 @@ public class VerticleTest {
 
     private final int port;
     private volatile VertxServer server;
-    private VertxGreeterGrpc.GreeterVertxImplBase service;
 
     public GrpcVerticle(int port) {
       this.port = port;
@@ -60,7 +59,7 @@ public class VerticleTest {
 
     @Override
     public void start(Promise<Void> startFuture) throws Exception {
-      service = new VertxGreeterGrpc.GreeterVertxImplBase() {
+      VertxGreeterGrpc.GreeterVertxImplBase service = new VertxGreeterGrpc.GreeterVertxImplBase() {
         @Override
         public Future<HelloReply> sayHello(HelloRequest request) {
           threads.add(Thread.currentThread());
@@ -117,9 +116,7 @@ public class VerticleTest {
   @Test
   public void testCloseInVerticle(TestContext ctx) throws Exception {
     Async started = ctx.async();
-    vertx.deployVerticle(GrpcVerticle.class.getName(), ctx.asyncAssertSuccess(id -> {
-      vertx.undeploy(id, ctx.asyncAssertSuccess(v -> started.complete()));
-    }));
+    vertx.deployVerticle(GrpcVerticle.class.getName(), ctx.asyncAssertSuccess(id -> vertx.undeploy(id, ctx.asyncAssertSuccess(v -> started.complete()))));
     started.awaitSuccess(10000);
     Async async = ctx.async();
     ManagedChannel channel= VertxChannelBuilder.forAddress(vertx, "localhost", 50051)


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Currently tests are written in a blocking fashion which is showing on windows CI to be troublesome.
This PR rewrites the tests in an async way to ensure that the code and tests are working on all tested OSes.
