### PR TITLE
Adding package-info

### DIFF
--- a/vertx-grpc/src/main/java/io/vertx/grpc/package-info.java
+++ b/vertx-grpc/src/main/java/io/vertx/grpc/package-info.java
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (c) 2011-2015 The original author or authors
+ *  ------------------------------------------------------
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+@ModuleGen(name = "vertx-grpc", groupPackage = "io.vertx")
+package io.vertx.grpc;
+
+import io.vertx.codegen.annotations.ModuleGen;


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Adding package-info so this module can be consumed by codegen projects.

This feature was present in the 3.x branch.