### PR TITLE
Bump gRPC version from 1.33.1 to 1.35.0

### DIFF
--- a/vertx-grpc/pom.xml
+++ b/vertx-grpc/pom.xml
@@ -33,7 +33,7 @@
     <jetty.alpnAgent.version>2.0.9</jetty.alpnAgent.version>
     <jetty.alpnAgent.path>${settings.localRepository}/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
 
-    <grpc.version>1.33.1</grpc.version>
+    <grpc.version>1.35.0</grpc.version>
     <protoc.version>3.14.0</protoc.version>
     <doc.skip>false</doc.skip>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>

--- a/vertx-grpc/src/main/java/examples/GreeterGrpc.java
+++ b/vertx-grpc/src/main/java/examples/GreeterGrpc.java
@@ -1,19 +1,6 @@
 package examples;
 
 import static io.grpc.MethodDescriptor.generateFullMethodName;
-import static io.grpc.stub.ClientCalls.asyncBidiStreamingCall;
-import static io.grpc.stub.ClientCalls.asyncClientStreamingCall;
-import static io.grpc.stub.ClientCalls.asyncServerStreamingCall;
-import static io.grpc.stub.ClientCalls.asyncUnaryCall;
-import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
-import static io.grpc.stub.ClientCalls.blockingUnaryCall;
-import static io.grpc.stub.ClientCalls.futureUnaryCall;
-import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
-import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
-import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
-import static io.grpc.stub.ServerCalls.asyncUnaryCall;
-import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
-import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
 
 /**
  * <pre>
@@ -21,7 +8,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.33.1)",
+    value = "by gRPC proto compiler (version 1.35.0)",
     comments = "Source: helloworld.proto")
 public final class GreeterGrpc {
 
@@ -119,14 +106,14 @@ public final class GreeterGrpc {
      */
     public void sayHello(examples.HelloRequest request,
         io.grpc.stub.StreamObserver<examples.HelloReply> responseObserver) {
-      asyncUnimplementedUnaryCall(getSayHelloMethod(), responseObserver);
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getSayHelloMethod(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
             getSayHelloMethod(),
-            asyncUnaryCall(
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
               new MethodHandlers<
                 examples.HelloRequest,
                 examples.HelloReply>(
@@ -159,7 +146,7 @@ public final class GreeterGrpc {
      */
     public void sayHello(examples.HelloRequest request,
         io.grpc.stub.StreamObserver<examples.HelloReply> responseObserver) {
-      asyncUnaryCall(
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
           getChannel().newCall(getSayHelloMethod(), getCallOptions()), request, responseObserver);
     }
   }
@@ -187,7 +174,7 @@ public final class GreeterGrpc {
      * </pre>
      */
     public examples.HelloReply sayHello(examples.HelloRequest request) {
-      return blockingUnaryCall(
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
           getChannel(), getSayHelloMethod(), getCallOptions(), request);
     }
   }
@@ -216,7 +203,7 @@ public final class GreeterGrpc {
      */
     public com.google.common.util.concurrent.ListenableFuture<examples.HelloReply> sayHello(
         examples.HelloRequest request) {
-      return futureUnaryCall(
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
           getChannel().newCall(getSayHelloMethod(), getCallOptions()), request);
     }
   }


### PR DESCRIPTION
The build fails unless vertx-dependencies update
Netty to 4.1.52.Final and TcNative to 2.0.34.Final.
PR for Netty and TcNative update:
https://github.com/vert-x3/vertx-dependencies/pull/54

The code in examples/GreeterGrpc.java is auto-generated and
the new gRPC version causes some changes.