### PR TITLE
Interceptor context shouldn't be locked to String, but allow any type

### DIFF
--- a/vertx-grpc/src/main/java/examples/Examples.java
+++ b/vertx-grpc/src/main/java/examples/Examples.java
@@ -280,8 +280,8 @@ public class Examples {
 
     ServerInterceptor contextInterceptor = new ContextServerInterceptor() {
       @Override
-      public void bind(Metadata metadata, ConcurrentMap<String, String> context) {
-        context.put("sessionId", metadata.get(SESSION_ID_METADATA_KEY));
+      public void bind(Metadata metadata) {
+        put("sessionId", metadata.get(SESSION_ID_METADATA_KEY));
       }
     };
 

--- a/vertx-grpc/src/test/java/io/vertx/ext/grpc/ContextTest.java
+++ b/vertx-grpc/src/test/java/io/vertx/ext/grpc/ContextTest.java
@@ -69,8 +69,8 @@ public class ContextTest extends GrpcTestBase {
 
     ServerInterceptor contextInterceptor = new ContextServerInterceptor() {
       @Override
-      public void bind(Metadata metadata, ConcurrentMap<String, String> context) {
-        context.put("sessionId", metadata.get(SESSION_ID_METADATA_KEY));
+      public void bind(Metadata metadata) {
+        put("sessionId", metadata.get(SESSION_ID_METADATA_KEY));
       }
     };
 
@@ -102,8 +102,8 @@ public class ContextTest extends GrpcTestBase {
 
     ServerInterceptor contextInterceptor = new ContextServerInterceptor() {
       @Override
-      public void bind(Metadata metadata, ConcurrentMap<String, String> context) {
-        context.put("sessionId", metadata.get(SESSION_ID_METADATA_KEY));
+      public void bind(Metadata metadata) {
+        put("sessionId", metadata.get(SESSION_ID_METADATA_KEY));
       }
     };
 


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

The current implementation bind only Strings to the context, however this is wrong. Any type should/can be allowed as it's just a map of references.

This PR requires a breaking change and hides the details of the storage by allowing any type to be stored in the context.