### PR TITLE
The internal gRPC server is using the channel event loop group for ac…

### DIFF
--- a/src/main/java/io/vertx/grpc/VertxServer.java
+++ b/src/main/java/io/vertx/grpc/VertxServer.java
@@ -48,7 +48,7 @@ public class VertxServer extends Server {
     final Server server;
     final ThreadLocal<List<ContextInternal>> contextLocal = new ThreadLocal<>();
 
-    private ActualServer(Vertx vertx,
+    private ActualServer(VertxInternal vertx,
                          ServerID id,
                          HttpServerOptions options,
                          NettyServerBuilder builder,
@@ -82,7 +82,7 @@ public class VertxServer extends Server {
       this.server = builder
           .executor(executor)
           .channelFactory(transport.serverChannelFactory(false))
-          .bossEventLoopGroup(group)
+          .bossEventLoopGroup(vertx.getAcceptorEventLoopGroup())
           .workerEventLoopGroup(group)
           .build();
     }


### PR DESCRIPTION
The internal gRPC server is using the channel event loop group for accepting as boss group.
    
This can limit performance and requires the channel event loop group to be eagerly populated.

We should instead use the Vert.x acceptor event loop group.
    
fixes #99
fixes #91
