### PR TITLE
Actually dispatch to the event loop in the executor

### DIFF
--- a/vertx-grpc/src/main/java/io/vertx/grpc/VertxServer.java
+++ b/vertx-grpc/src/main/java/io/vertx/grpc/VertxServer.java
@@ -86,9 +86,11 @@ public class VertxServer extends Server {
 
       this.id = id;
       this.options = options;
-      Executor executor = command -> contextLocal.get().get(0).dispatch(event -> command.run());
-      if (commandDecorator != null) {
-        executor = command -> contextLocal.get().get(0).dispatch(event -> commandDecorator.accept(command));
+      Executor executor;
+      if (commandDecorator == null) {
+        executor = command -> contextLocal.get().get(0).runOnContext(event -> command.run());
+      }else{
+        executor = command -> contextLocal.get().get(0).runOnContext(event -> commandDecorator.accept(command));
       }
       this.server = builder
           .executor(executor)


### PR DESCRIPTION
Motivation:

If you don't dispatch then when using MTLS you can end up with a
situation where a SSL read dispatches another read to the executor, and
with no dispatch you end up with a re-entrant read. This read will
handle all the data and free the buffer, and when the call stack returns
the outer read will fail with an invalid reference count as the buffer
is freed by the re-entrant read.

This causes the problems seen in https://github.com/quarkusio/quarkus/pull/19426 attempting to upgrade Quarkus to the latest version of Netty.