### PR TITLE
Bump jprotoc from 1.2.0 to 1.2.1

### DIFF
--- a/vertx-grpc-protoc-plugin/pom.xml
+++ b/vertx-grpc-protoc-plugin/pom.xml
@@ -13,7 +13,7 @@
 
   <artifactId>vertx-grpc-protoc-plugin</artifactId>
   <properties>
-    <jprotoc.version>1.2.0</jprotoc.version>
+    <jprotoc.version>1.2.1</jprotoc.version>
     <canteen.version>1.1.0</canteen.version>
   </properties>
 


### PR DESCRIPTION
See https://github.com/salesforce/grpc-java-contrib/pull/171 and https://github.com/vert-x3/vertx-grpc/pull/95
