### PR TITLE
Bump protoc.version from 3.19.2 to 3.21.5

### DIFF
--- a/vertx-grpc/pom.xml
+++ b/vertx-grpc/pom.xml
@@ -31,7 +31,7 @@
 
   <properties>
     <grpc.version>1.47.0</grpc.version>
-    <protoc.version>3.19.2</protoc.version>
+    <protoc.version>3.21.5</protoc.version>
     <doc.skip>false</doc.skip>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>


### PR DESCRIPTION
It does not seem that dependabot understands this syntax

See : https://github.com/dependabot/dependabot-core/issues/5438