### PR TITLE
Added exception Handler for Many to Many stream

### DIFF
--- a/vertx-grpc-protoc-plugin/src/main/resources/VertxStub.mustache
+++ b/vertx-grpc-protoc-plugin/src/main/resources/VertxStub.mustache
@@ -70,6 +70,10 @@ public final class {{className}} {
         public io.vertx.core.streams.ReadStream<{{outputType}}> {{methodName}}(io.vertx.core.Handler<io.vertx.core.streams.WriteStream<{{inputType}}>> hdlr) {
             return io.vertx.grpc.stub.ClientCalls.{{vertxCallsMethodName}}(ctx, hdlr, delegateStub::{{methodName}});
         }
+
+        public io.vertx.core.streams.ReadStream<{{outputType}}> {{methodName}}WithExceptionHandler(io.vertx.core.Handler<io.vertx.core.streams.WriteStream<{{inputType}}>> hdlr, io.vertx.core.Handler<java.lang.Throwable> exceptionHandler) {
+            return io.vertx.grpc.stub.ClientCalls.{{vertxCallsMethodName}}(ctx, hdlr, delegateStub::{{methodName}}, exceptionHandler);
+        }
         {{/manyManyMethods}}
     }
 

--- a/vertx-grpc/src/main/java/io/vertx/grpc/stub/ClientCalls.java
+++ b/vertx-grpc/src/main/java/io/vertx/grpc/stub/ClientCalls.java
@@ -56,7 +56,12 @@ public final class ClientCalls {
   }
 
   public static <I, O> ReadStream<O> manyToMany(ContextInternal ctx, Handler<WriteStream<I>> requestHandler, Function<StreamObserver<O>, StreamObserver<I>> delegate) {
+    return manyToMany(ctx, requestHandler, delegate, null);
+  }
+
+  public static <I, O> ReadStream<O> manyToMany(ContextInternal ctx, Handler<WriteStream<I>> requestHandler, Function<StreamObserver<O>, StreamObserver<I>> delegate, Handler<Throwable> exceptionHandler) {
     StreamObserverReadStream<O> response = new StreamObserverReadStream<>();
+    response.exceptionHandler(exceptionHandler);
     StreamObserver<I> request = delegate.apply(response);
     requestHandler.handle(new GrpcWriteStream<>(request));
     return response;


### PR DESCRIPTION
when `io.vertx.grpc.stub.ClientCalls.manyToMany` called if exception happens before returning the StreamObserverReadStream  exception is lost.There is no way to register exceptionHandler before the call.We can register exceptionHandler only after `StreamObserverReadStream` return from `manyToMany`.

Fix for https://github.com/vert-x3/vertx-grpc/issues/141
