### PR TITLE
bump grpc.version

### DIFF
--- a/vertx-grpc/pom.xml
+++ b/vertx-grpc/pom.xml
@@ -30,7 +30,7 @@
   <name>Vert.x gRPC</name>
 
   <properties>
-    <grpc.version>1.61.0</grpc.version>
+    <grpc.version>1.65.0</grpc.version>
     <protoc.version>3.21.12</protoc.version>
     <doc.skip>false</doc.skip>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>


### PR DESCRIPTION
Follow the master branch.
1.61.0 doesn't work with netty 4.1.111
