### PR TITLE
Deprecate this project in favor of Vert.x gRPC

### DIFF
--- a/vertx-grpc-protoc-plugin/src/main/java/io/vertx/grpc/protoc/plugin/VertxGrpcGenerator.java
+++ b/vertx-grpc-protoc-plugin/src/main/java/io/vertx/grpc/protoc/plugin/VertxGrpcGenerator.java
@@ -17,7 +17,9 @@ import java.util.stream.Collectors;
 
 /**
  * @author Rogelio Orts
+ * @deprecated instead use Vert.x gRPC
  */
+@Deprecated
 public class VertxGrpcGenerator extends Generator {
 
   private static final int SERVICE_NUMBER_OF_PATHS = 2;

--- a/vertx-grpc/src/main/asciidoc/index.adoc
+++ b/vertx-grpc/src/main/asciidoc/index.adoc
@@ -1,5 +1,7 @@
 = Vert.x gRPC
 
+WARNING: this project is deprecated for removal, instead Vert.x gRPC should be used.
+
 The best description of gRPC can be seen at wikipedia.
 
 [quote, wikipedia, wikipedia]

--- a/vertx-grpc/src/main/java/io/vertx/grpc/BlockingServerInterceptor.java
+++ b/vertx-grpc/src/main/java/io/vertx/grpc/BlockingServerInterceptor.java
@@ -28,7 +28,9 @@ import java.util.function.Consumer;
  *
  * @author <a href="mailto:pkopachevskiy@corp.finam.ru">Pavel Kopachevskiy</a>
  * @author <a href="mailto:ruslan.sennov@gmail.com">Ruslan Sennov</a>
+ * @deprecated instead use Vert.x gRPC
  */
+@Deprecated
 public class BlockingServerInterceptor implements ServerInterceptor {
 
   public static ServerInterceptor wrap(Vertx vertx, ServerInterceptor interceptor) {

--- a/vertx-grpc/src/main/java/io/vertx/grpc/ContextServerInterceptor.java
+++ b/vertx-grpc/src/main/java/io/vertx/grpc/ContextServerInterceptor.java
@@ -31,7 +31,10 @@ import java.util.concurrent.ConcurrentMap;
 /**
  * An abstract interceptor that allows capturing data from the metadata to the vertx context so it can be used later
  * on the asynchronous APIs.
+ *
+ * @deprecated instead use Vert.x gRPC
  */
+@Deprecated
 public abstract class ContextServerInterceptor implements ServerInterceptor {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ContextServerInterceptor.class);

--- a/vertx-grpc/src/main/java/io/vertx/grpc/VertxChannelBuilder.java
+++ b/vertx-grpc/src/main/java/io/vertx/grpc/VertxChannelBuilder.java
@@ -27,7 +27,6 @@ import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.internal.tls.SslContextManager;
 import io.vertx.core.internal.tls.SslContextProvider;
 import io.vertx.core.net.ClientOptionsBase;
-import io.vertx.core.net.impl.tcp.NetServerImpl;
 import io.vertx.core.spi.transport.Transport;
 
 import javax.annotation.Nullable;
@@ -44,7 +43,9 @@ import java.util.concurrent.TimeoutException;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ * @deprecated instead use Vert.x gRPC
  */
+@Deprecated(forRemoval = true)
 public class VertxChannelBuilder extends ManagedChannelBuilder<VertxChannelBuilder> {
 
   private static String authorityFromHostAndPort(String host, int port) {

--- a/vertx-grpc/src/main/java/io/vertx/grpc/VertxServer.java
+++ b/vertx-grpc/src/main/java/io/vertx/grpc/VertxServer.java
@@ -26,7 +26,6 @@ import io.vertx.core.internal.PromiseInternal;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.internal.tls.SslContextManager;
 import io.vertx.core.internal.tls.SslContextProvider;
-import io.vertx.core.net.impl.tcp.NetServerImpl;
 import io.vertx.core.net.impl.ServerID;
 import io.vertx.core.net.impl.VertxEventLoopGroup;
 import io.vertx.core.spi.transport.Transport;
@@ -46,7 +45,9 @@ import java.util.function.Consumer;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ * @deprecated instead use Vert.x gRPC
  */
+@Deprecated(forRemoval = true)
 public class VertxServer extends Server {
 
   private static final ConcurrentMap<ServerID, ActualServer> map = new ConcurrentHashMap<>();

--- a/vertx-grpc/src/main/java/io/vertx/grpc/VertxServerBuilder.java
+++ b/vertx-grpc/src/main/java/io/vertx/grpc/VertxServerBuilder.java
@@ -35,7 +35,9 @@ import java.util.function.Consumer;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ * @deprecated instead use Vert.x gRPC
  */
+@Deprecated(forRemoval = true)
 public class VertxServerBuilder extends ServerBuilder<VertxServerBuilder> {
 
   public static VertxServerBuilder forPort(Vertx vertx, int port) {

--- a/vertx-grpc/src/main/java/io/vertx/grpc/package-info.java
+++ b/vertx-grpc/src/main/java/io/vertx/grpc/package-info.java
@@ -13,6 +13,7 @@
  *
  *  You may elect to redistribute this code under either of these licenses.
  */
+
 @ModuleGen(name = "vertx-grpc", groupPackage = "io.vertx")
 package io.vertx.grpc;
 

--- a/vertx-grpc/src/main/java/io/vertx/grpc/stub/ClientCalls.java
+++ b/vertx-grpc/src/main/java/io/vertx/grpc/stub/ClientCalls.java
@@ -30,7 +30,9 @@ import java.util.function.Function;
 /**
  * @author Rogelio Orts
  * @author Eduard Català
+ * @deprecated instead use Vert.x gRPC
  */
+@Deprecated
 public final class ClientCalls {
 
   private ClientCalls() {

--- a/vertx-grpc/src/main/java/io/vertx/grpc/stub/GrpcWriteStream.java
+++ b/vertx-grpc/src/main/java/io/vertx/grpc/stub/GrpcWriteStream.java
@@ -22,9 +22,10 @@ import io.vertx.core.Handler;
 import io.vertx.core.streams.WriteStream;
 
 /**
- *
  * @author ecatala
+ * @deprecated instead use Vert.x gRPC
  */
+@Deprecated
 public class GrpcWriteStream<T> implements WriteStream<T> {
 
   private final StreamObserver<T> observer;

--- a/vertx-grpc/src/main/java/io/vertx/grpc/stub/ServerCalls.java
+++ b/vertx-grpc/src/main/java/io/vertx/grpc/stub/ServerCalls.java
@@ -30,7 +30,9 @@ import java.util.function.Function;
 /**
  * @author Rogelio Orts
  * @author Eduard Català
+ * @deprecated instead use Vert.x gRPC
  */
+@Deprecated(forRemoval = true)
 public final class ServerCalls {
 
   private ServerCalls() {

--- a/vertx-grpc/src/main/java/io/vertx/grpc/stub/StreamObserverReadStream.java
+++ b/vertx-grpc/src/main/java/io/vertx/grpc/stub/StreamObserverReadStream.java
@@ -22,7 +22,9 @@ import io.vertx.core.streams.ReadStream;
 
 /**
  * @author Rogelio Orts
+ * @deprecated instead use Vert.x gRPC
  */
+@Deprecated
 class StreamObserverReadStream<T> implements StreamObserver<T>, ReadStream<T> {
 
   private Handler<Throwable> exceptionHandler;


### PR DESCRIPTION
We cannot reasonable support this project as is since it is based on Netty 4.1 while Vert.x relies on 4.2.

It could be adapted to use `grpc-netty-shaded` instead, but that would mean breaking changes and the incapacity to share classes with Vert.x which implies different event-loop, different SSL configuration, etc...

Users should move to [Vert.x gRPC](https://github.com/eclipse-vertx/vertx-grpc)